### PR TITLE
Split shaderplace into 2 different modes.

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Shader.Place</title>
+    <script src="fragmentShader.js" defer></script>
+    
+    <link rel=stylesheet href="https://codemirror.net/lib/codemirror.css"  async defer>
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <link rel="stylesheet" href="./node_modules/codemirror/addon/lint/lint.css">
+    <script type="text/javascript" src="./dist/codemirror.bundle.js" async></script>
+
+  </head>
+  <body>
+
+     <div id="videos">
+        <div id="subscriber"></div>
+        <div id="publisher"></div>
+    </div>
+    <div id="container"></div>
+    <div id="webcam" class="float"></div>
+    <video></video>
+
+  </body>
+</html>

--- a/editor.js
+++ b/editor.js
@@ -114,7 +114,12 @@ function initializeSession() {
 function initYdoc() {
   console.log("in init doc")
   const ydoc = new Y.Doc();
-  var room = document.getElementById("room").value;
+
+  const searchParams = new URLSearchParams(window.location.search);
+  var room = "";
+  if (searchParams.has("room")){
+    room = searchParams.get("room");
+  }
 
   const provider = new WebsocketProvider(
     "wss://demos.yjs.dev",
@@ -210,11 +215,9 @@ function updateScene() {
 }
 
 window.onload = (event) => {
-  var goButton = document.getElementById("goButton");
-  goButton.onclick = initYdoc;
   var webcamButton = document.getElementById("webcam");
   webcamButton.onclick = initializeSession;
-  //goButton.click();
+  initYdoc();
 }
 
 function init() {

--- a/editor.js
+++ b/editor.js
@@ -110,6 +110,19 @@ function initializeSession() {
 
 }
 
+function isInPresentationMode() {
+  if (window.location.pathname.split('/').pop() == 'present.html') {
+    return true;
+  }
+  return false;
+}
+
+function addCodeMirrorPresentModifier() {
+  const codeMirrorDiv = document.querySelector(".CodeMirror");
+  if (codeMirrorDiv) {
+    codeMirrorDiv.classList.add("CodeMirror-present");
+  }
+}
 
 function initYdoc() {
   console.log("in init doc")
@@ -126,10 +139,8 @@ function initYdoc() {
     room,
     ydoc
   );
-  const editorContainer = document.createElement("div");
-  editorContainer.setAttribute("id", "editor");
-  document.body.insertBefore(editorContainer, null);
 
+  var editorContainer = document.getElementById("editor");
   editor = CodeMirror(editorContainer, {
     value: _fragmentShader,
     lineNumbers: true,
@@ -166,6 +177,9 @@ function initYdoc() {
     }
   );
 
+  if (isInPresentationMode()) {
+    addCodeMirrorPresentModifier();
+  }
 
   // @ts-ignore
   window.example = { provider, ydoc, ytext, binding, Y };
@@ -266,7 +280,10 @@ function init() {
 }
 
 function onWindowResize(event) {
-  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setSize(container.offsetWidth, container.offsetHeight);
+  if (isInPresentationMode()) {
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  }
   uniforms.u_resolution.value.x = renderer.domElement.width;
   uniforms.u_resolution.value.y = renderer.domElement.height;
   uniforms.resolution.value.x = renderer.domElement.width;

--- a/editor.js
+++ b/editor.js
@@ -146,7 +146,8 @@ function initYdoc() {
     lineNumbers: true,
     mode: "x-shader/x-vertex",
     gutters: ["CodeMirror-lint-markers"],
-    lint: true
+    lint: true,
+    lineWrapping: !isInPresentationMode()
   });
 
   const ytext = ydoc.getText("codemirror");

--- a/index.html
+++ b/index.html
@@ -8,32 +8,25 @@
     <link rel=stylesheet href="https://codemirror.net/lib/codemirror.css"  async defer>
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="stylesheet" href="./node_modules/codemirror/addon/lint/lint.css">
-    <script type="text/javascript" src="./dist/codemirror.bundle.js" async></script>
-
+    <script type="text/javascript" src="./dist/index.bundle.js" async></script>
   </head>
   <body>
-
-     <div id="videos">
-        <div id="subscriber"></div>
-        <div id="publisher"></div>
-    </div>
-
-    <div id="container"></div>
     <div id="enterScreen">
-    <h1>Welcome to Shader.Place</h1>
-    <h2>
-      A real-time collaborative GLSL livecode editor
-    </h2><br><br>
-    <input type="text" placeholder="Enter a room name" id="room">
-    <button type="button" id="goButton" >Go</button></div>
+      <h1>Welcome to Shader.Place</h1>
+      <h2>
+        A real-time collaborative GLSL livecode editor
+      </h2><br><br>
+      <input type="text" placeholder="Enter a room name" id="room">
+      <button type="button" id="goButton" >Go</button></div>
 
-    <h3><br><br>
-      To make suggestions, report an issue, contribute or fork go to: <a href="https://github.com/CharStiles/shaderplace">https://github.com/CharStiles/shaderplace</a> 
-    <br>
-    or email contact at charstiles.com
-    </h3>
-    <div id="webcam" class="float"></div>
-    <video></video>
+      <h3><br><br>
+        To make suggestions, report an issue, contribute or fork go to: <a href="https://github.com/CharStiles/shaderplace">https://github.com/CharStiles/shaderplace</a>
+      <br>
+      or email contact at charstiles.com
+      </h3>
+      <div id="webcam" class="float"></div>
+      <video></video>
+    </div>
 
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,10 @@
       <h2>
         A real-time collaborative GLSL livecode editor
       </h2><br><br>
-      <input type="text" placeholder="Enter a room name" id="room">
-      <button type="button" id="goButton" >Go</button></div>
+      <input type="text" placeholder="Enter a room name" id="room" />
+      <button type="button" id="editButton" >Edit</button>
+      <button type="button" id="presentButton" >Present</button>
+    </div>
 
       <h3><br><br>
         To make suggestions, report an issue, contribute or fork go to: <a href="https://github.com/CharStiles/shaderplace">https://github.com/CharStiles/shaderplace</a>

--- a/index.js
+++ b/index.js
@@ -1,9 +1,16 @@
 window.onload = (event) => {
-  var goButton = document.getElementById("goButton");
-  goButton.onclick = sendToEditor;
+  var editButton = document.getElementById("editButton");
+  editButton.onclick = sendToEditor;
+  var presentButton = document.getElementById("presentButton");
+  presentButton.onclick = sendToPresenter;
 }
 
 function sendToEditor() {
   var room = document.getElementById("room").value;
   window.location.href = "./edit.html?room=" + room;
+}
+
+function sendToPresenter() {
+  var room = document.getElementById("room").value;
+  window.location.href = "./present.html?room=" + room;
 }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+window.onload = (event) => {
+  var goButton = document.getElementById("goButton");
+  goButton.onclick = sendToEditor;
+}
+
+function sendToEditor() {
+  var room = document.getElementById("room").value;
+  window.location.href = "./edit.html?room=" + room;
+}

--- a/present.html
+++ b/present.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Shader.Place</title>
     <script src="fragmentShader.js" defer></script>
-    
+
     <link rel=stylesheet href="https://codemirror.net/lib/codemirror.css"  async defer>
     <link rel="stylesheet" type="text/css" href="style.css" title="shaderplace">
     <link rel="stylesheet" href="./node_modules/codemirror/addon/lint/lint.css">
@@ -13,18 +13,14 @@
   </head>
   <body>
 
-    <div class="wrapper">
-      <div class="editor" id="editor"></div>
-      <div class="displaywrapper">
-        <div class="container-edit" id="container"></div>
-      </div>
-    </div>
-
     <div id="videos">
       <div id="subscriber"></div>
       <div id="publisher"></div>
     </div>
+    <div id="container" class="container-present"></div>
     <div id="webcam" class="float"></div>
     <video></video>
+
+    <div id="editor"></div>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -112,6 +112,7 @@ footer {
 
 .editor {
   width: 45%;
+  max-height: 100vh;
 }
 
 .displaywrapper {

--- a/style.css
+++ b/style.css
@@ -99,20 +99,54 @@ footer {
 .hidden {
   display: none;
 }
+
+.wrapper {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: left;
+  align-items: left;
+  height: 100%;
+  width: 100%;
+}
+
+.editor {
+  width: 45%;
+}
+
+.displaywrapper {
+  height: 100%;
+  width: 100%;
+}
+
 #enterScreen { caret-color: red; text-align: center; z-index:-100}
-#container {}
+
+.container-edit {
+  height: 100vh;
+  width: 100%;
+}
+
+.container-present {
+  height: 100%;
+  width: 100%;
+}
+
 #room{width: 30%;    
     margin-left: auto;
     margin-right: auto}
-.CodeMirror {
-  position: absolute !important;
-  top: 0; left: 0;
+
+.CodeMirror-present {
   background-color: rgba(255, 255, 255, 0.0) !important;
   text-shadow: 1px 1px #555555;
-  /* width: 50%; */
-  height: 100% !important;
-  scrollbar-color: rgba(0.5,0.5,0.5,1.0) rgba(0.5,0.5,0.5,.0);
   caret-color: red !important;
+  scrollbar-color: rgba(0.5,0.5,0.5,1.0) rgba(0.5,0.5,0.5,.0);
+  position: absolute !important;
+  top: 0;
+  left: 0;
+}
+
+.CodeMirror {
+  height: 100% !important;
 }
 
 .float{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,8 @@ module.exports = {
   mode: 'development',
   devtool: 'source-map',
   entry: {
-    codemirror: './editor.js'
+    codemirror: './editor.js',
+    index: './index.js'
   },
   output: {
     globalObject: 'self',


### PR DESCRIPTION
This pull request will split shaderplace into 2 different modes: editor and presenter. Presenter mode will be identical to the current state, while editor allows side-by-side editing of the shader.

In order to accomplish this the change:
* Moves shaderplace away from single-page style. This PR has 3 pages: index.html, edit.html, and present.html
* Modifies the landing page (index.html) to give entry points to both edit and present modes.
* Puts the room name into the url parameters
* Modifies the css based on whether the user is in edit or presentation mode.

Happy to talk more about this and hope you find this helpful!