### PR TITLE
Switch to using webgl + canvas directly

### DIFF
--- a/defaultShaders.js
+++ b/defaultShaders.js
@@ -36,3 +36,24 @@ void main(void)
 }
 
 `;
+
+var _vertexShader = `
+    attribute vec3 aVertexPosition;
+    attribute vec4 aVertexColor;
+    attribute vec2 aVertexTime;
+
+    uniform mat4 uMVMatrix;
+    uniform mat4 uPMatrix;
+
+    varying vec4 vColor;
+    varying vec3 vPosition;
+    varying vec2 vTime;
+
+    void main(void) {
+        gl_Position = uPMatrix * uMVMatrix * vec4(aVertexPosition, 1.0);
+        vColor = aVertexColor / 2.0;
+        vPosition = aVertexPosition;
+        vTime = aVertexTime;
+    }
+`;
+

--- a/defaultShaders.js
+++ b/defaultShaders.js
@@ -6,19 +6,14 @@ precision mediump float;
 #endif
 
 uniform vec2 u_resolution;
-uniform vec2 u_mouse;
 uniform float u_time;
-uniform vec2 resolution;
-uniform float time;
-uniform sampler2D u_feed;
-uniform sampler2D u_feed0;
 
 // main is a reserved function that is going to be called first
 void main(void)
 {
     vec2 normCoord = gl_FragCoord.xy/u_resolution;
     
-    float time = u_time/5.0; //slow down time
+    float time = u_time/500.0; //slow down time
 
     vec2 uv = -1. + 2. * normCoord;
     float r = sin(time + uv.x); 
@@ -38,22 +33,13 @@ void main(void)
 `;
 
 var _vertexShader = `
-    attribute vec3 aVertexPosition;
-    attribute vec4 aVertexColor;
-    attribute vec2 aVertexTime;
+attribute vec2 aVertexPosition;
 
-    uniform mat4 uMVMatrix;
-    uniform mat4 uPMatrix;
+uniform vec2 uScalingFactor;
 
-    varying vec4 vColor;
-    varying vec3 vPosition;
-    varying vec2 vTime;
+void main() {
+  gl_Position = vec4(aVertexPosition * uScalingFactor, 0.0, 1.0);
+}
 
-    void main(void) {
-        gl_Position = uPMatrix * uMVMatrix * vec4(aVertexPosition, 1.0);
-        vColor = aVertexColor / 2.0;
-        vPosition = aVertexPosition;
-        vTime = aVertexTime;
-    }
 `;
 

--- a/edit.html
+++ b/edit.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Shader.Place</title>
-    <script src="fragmentShader.js" defer></script>
+    <script src="defaultShaders.js" defer></script>
     
     <link rel=stylesheet href="https://codemirror.net/lib/codemirror.css"  async defer>
     <link rel="stylesheet" type="text/css" href="style.css" title="shaderplace">

--- a/edit.html
+++ b/edit.html
@@ -15,9 +15,13 @@
 
     <div class="wrapper">
       <div class="editor" id="editor"></div>
-      <div class="displaywrapper">
+      <canvas id="glcanvas" width="600" height="460">
+          Oh no! Your browser doesn't support canvas!
+      </canvas>
+
+      <!--<div class="displaywrapper">
         <div class="container-edit" id="container"></div>
-      </div>
+      </div> -->
     </div>
   </body>
 </html>

--- a/edit.html
+++ b/edit.html
@@ -15,13 +15,11 @@
 
     <div class="wrapper">
       <div class="editor" id="editor"></div>
-      <canvas id="glcanvas" width="600" height="460">
-          Oh no! Your browser doesn't support canvas!
-      </canvas>
-
-      <!--<div class="displaywrapper">
-        <div class="container-edit" id="container"></div>
-      </div> -->
+      <div class="displaywrapper">
+        <canvas id="glcanvas" class="container-edit">
+            Oh no! Your browser doesn't support canvas!
+        </canvas>
+      </div>
     </div>
   </body>
 </html>

--- a/edit.html
+++ b/edit.html
@@ -16,7 +16,7 @@
     <div class="wrapper">
       <div class="editor" id="editor"></div>
       <div class="displaywrapper">
-        <canvas id="glcanvas" class="container-edit">
+        <canvas id="glcanvas" class="container">
             Oh no! Your browser doesn't support canvas!
         </canvas>
       </div>

--- a/editor.js
+++ b/editor.js
@@ -79,7 +79,6 @@ function addCodeMirrorPresentModifier() {
 }
 
 function initYdoc() {
-  console.log("in init doc")
   const ydoc = new Y.Doc();
 
   const searchParams = new URLSearchParams(window.location.search);
@@ -138,11 +137,6 @@ function initYdoc() {
 
   // @ts-ignore
   window.example = { provider, ydoc, ytext, binding, Y };
-  //editor.on("change", onEdit);
-  //linter takes care of calling checkFragmentShader so we dont need
-  // this editor.on function
-  onEdit();
-  //animate();
 }
 
 
@@ -221,7 +215,7 @@ function compileShader(type, code) {
     if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
           console.log(`Error compiling ${type === gl.VERTEX_SHADER ? "vertex" : "fragment"} shader:`);
           console.log(gl.getShaderInfoLog(shader));
-        }
+    }
     return shader;
 }
 
@@ -245,7 +239,6 @@ function buildShaderProgram() {
 
   return program;
 }
-
 
 function webgl_startup() {
   glCanvas = document.getElementById("glcanvas");

--- a/editor.js
+++ b/editor.js
@@ -9,28 +9,22 @@ import "codemirror/mode/clike/clike.js";
 import 'codemirror/addon/lint/lint';
 import {__fragmentShader, __vertexShader} from "./defaultShaders.js";
 
+// Element storage
 var gl;
-
 var editor;
-
-var isDirty = false;
-
-
-// **** BEGIN webgl stuff
-
-// let gl = null; Already exists
 let glCanvas = null;
+
+// Current state storage
+var isDirty = false;
 let shaderProgram;
 
 // Aspect ratio and coordinate system
 // details
-
 let aspectRatio;
 let currentScale = [1.0, 1.0];
 let resolution;
 
 // Vertex information
-
 let vertexArray;
 let vertexBuffer;
 let vertexNumComponents;
@@ -38,17 +32,13 @@ let vertexCount;
 
 // Rendering data shared with the
 // scalers.
-
 let uScalingFactor;
 let uResolution;
 let uTime;
 let aVertexPosition;
 
 // Animation timing
-
 let previousTime = 0.0;
-
-// ******* END webgl stuff
 
 
 function isInPresentationMode() {
@@ -148,9 +138,6 @@ window.onload = (event) => {
   initYdoc();
 }
 
-// START COPIED SECTION
-// Copied from
-// https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example
 function animateScene() {
     gl.viewport(0, 0, glCanvas.width, glCanvas.height);
     // This sets background color
@@ -262,8 +249,6 @@ function webgl_startup() {
   animateScene();
 }
 
-
-// DONE WITH COPIED SECTION
 
 function vertexShader() {
   return _vertexShader;

--- a/editor.js
+++ b/editor.js
@@ -9,10 +9,6 @@ import "codemirror/mode/clike/clike.js";
 import 'codemirror/addon/lint/lint';
 import {__fragmentShader, __vertexShader} from "./defaultShaders.js";
 
-const OT = require('@opentok/client');
-
-var uniforms;
-
 var gl;
 
 var editor;
@@ -46,22 +42,13 @@ let vertexCount;
 let uScalingFactor;
 let uResolution;
 let uTime;
-let uRotationVector;
 let aVertexPosition;
 
 // Animation timing
 
 let previousTime = 0.0;
-let degreesPerSecond = 90.0;
 
 // ******* END webgl stuff
-
-// Handling all of our errors here by alerting them
-function handleError(error) {
-  if (error) {
-    alert(error.message);
-  }
-}
 
 
 function isInPresentationMode() {
@@ -278,72 +265,12 @@ function webgl_startup() {
 
 // DONE WITH COPIED SECTION
 
-// TODO call this with
-// window.addEventListener("resize", onWindowResize, false);
-function onWindowResize(event) {
-  renderer.setSize(container.offsetWidth, container.offsetHeight);
-  if (isInPresentationMode()) {
-    renderer.setSize(window.innerWidth, window.innerHeight);
-  }
-  uniforms.u_resolution.value.x = renderer.domElement.width;
-  uniforms.u_resolution.value.y = renderer.domElement.height;
-  uniforms.resolution.value.x = renderer.domElement.width;
-  uniforms.resolution.value.y = renderer.domElement.height;
-}
-
-function animate() {
-  requestAnimationFrame(animate);
-  render();
-}
-
-function render() {
-  if (isDirty) {
-    updateScene();
-  }
-  uniforms.u_time.value += 0.05;
-  uniforms.time.value += 0.05;
-  renderer.render(scene, threeCam);
-}
-
-/*
 function vertexShader() {
-  return `        
-    void main() {
-      gl_Position = vec4( position, 1.0 );
-    }
-  `;
-}
-*/
-
-function vertexShader() {
-  return `
-attribute vec2 aVertexPosition;
-
-uniform vec2 uScalingFactor;
-
-void main() {
-      gl_Position = vec4(aVertexPosition * uScalingFactor, 0.0, 1.0);
-}
-`;
+  return _vertexShader;
 }
 
 function fragmentShader() {
   return _fragmentShader;
-}
-
-function fragmentShaderNew() {
-  return `
-#ifdef GL_ES
-    precision highp float;
-  #endif
-
-  uniform vec2 u_resolution;
-  uniform float u_time;
-
-  void main() {
-        gl_FragColor = vec4(gl_FragCoord.y / u_resolution.y, gl_FragCoord.x / u_resolution.x, sin(u_time * .001), 1.0);
-}
-  `;
 }
 
 // this returns false if the fragment shader cannot compile

--- a/editor.js
+++ b/editor.js
@@ -7,7 +7,7 @@ import { WebsocketProvider } from "y-websocket";
 import { CodemirrorBinding } from "y-codemirror";
 import "codemirror/mode/clike/clike.js";
 import 'codemirror/addon/lint/lint';
-import __fragmentShader from "./fragmentShader.js";
+import {__fragmentShader, __vertexShader} from "./defaultShaders.js";
 import * as THREE from "three";
 
 const OT = require('@opentok/client');

--- a/editor.js
+++ b/editor.js
@@ -52,6 +52,7 @@ let vertexCount;
 let uScalingFactor;
 let uGlobalColor;
 let uResolution;
+let uTime;
 let uRotationVector;
 let aVertexPosition;
 
@@ -210,10 +211,13 @@ function animateScene() {
           gl.getUniformLocation(shaderProgram, "uGlobalColor");
     uResolution =
           gl.getUniformLocation(shaderProgram, "u_resolution");
+    uTime =
+          gl.getUniformLocation(shaderProgram, "u_time");
 
     gl.uniform2fv(uScalingFactor, currentScale);
     gl.uniform4fv(uGlobalColor, [0.1, 0.7, 0.2, 1.0]);
     gl.uniform2fv(uResolution, resolution);
+    gl.uniform1f(uTime, previousTime);
 
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
 
@@ -384,9 +388,10 @@ function fragmentShaderNew() {
 
   uniform vec4 uGlobalColor;
   uniform vec2 u_resolution;
+  uniform float u_time;
 
   void main() {
-        gl_FragColor = vec4(gl_FragCoord.y / u_resolution.y, gl_FragCoord.x / u_resolution.x, 0.,1.0);
+        gl_FragColor = vec4(gl_FragCoord.y / u_resolution.y, gl_FragCoord.x / u_resolution.x, sin(u_time * .001), 1.0);
 }
   `;
 }

--- a/editor.js
+++ b/editor.js
@@ -149,15 +149,15 @@ function initYdoc() {
   //linter takes care of calling checkFragmentShader so we dont need
   // this editor.on function
   onEdit();
-  init();
-  animate();
+  //init();
+  //animate();
 }
 
 
 // this function will trigger a change to the editor
 function onEdit() {
   const fragmentCode = editor.getValue();
-  updateShader(fragmentCode);
+  //updateShader(fragmentCode);
 }
 
 function updateShader(fragmentCode) {
@@ -167,7 +167,7 @@ function updateShader(fragmentCode) {
 
   _fragmentShader = fragmentCode;
 
-  isDirty = true;
+  //isDirty = true;
 }
 
 function updateScene() {
@@ -191,7 +191,7 @@ function updateScene() {
 
 window.onload = (event) => {
   webgl_startup();
-  //initYdoc();
+  initYdoc();
 }
 
 // START COPIED SECTION

--- a/editor.js
+++ b/editor.js
@@ -242,6 +242,12 @@ function buildShaderProgram() {
 
 function webgl_startup() {
   glCanvas = document.getElementById("glcanvas");
+  if (glCanvas.width != glCanvas.clientWidth) {
+    glCanvas.width = glCanvas.clientWidth;
+  }
+  if (glCanvas.height != glCanvas.clientHeight) {
+    glCanvas.height = glCanvas.clientHeight;
+  }
   gl = glCanvas.getContext("webgl");
 
   shaderProgram = buildShaderProgram();

--- a/editor.js
+++ b/editor.js
@@ -201,8 +201,14 @@ function animateScene() {
     gl.drawArrays(gl.TRIANGLES, 0, vertexCount);
 
     window.requestAnimationFrame(function(currentTime) {
-          previousTime = currentTime;
-          animateScene();
+      previousTime = currentTime;
+      // TODO here check dirty bit and recompile?
+      if (isDirty) {
+        // recompile and clear dirty bit
+        shaderProgram = buildShaderProgram();
+        isDirty = false;
+      }
+      animateScene();
     });
 }
 
@@ -224,11 +230,11 @@ function buildShaderProgram() {
   let program = gl.createProgram();
     
   // Compile vertex shader
-  let shader = compileShader(gl.VERTEX_SHADER, vertexShaderNew());
+  let shader = compileShader(gl.VERTEX_SHADER, vertexShader());
   gl.attachShader(program, shader);
 
   // Compile fragment shader
-  shader = compileShader(gl.FRAGMENT_SHADER, fragmentShaderNew());
+  shader = compileShader(gl.FRAGMENT_SHADER, fragmentShader());
   gl.attachShader(program, shader);
 
   gl.linkProgram(program)
@@ -300,6 +306,7 @@ function render() {
   renderer.render(scene, threeCam);
 }
 
+/*
 function vertexShader() {
   return `        
     void main() {
@@ -307,8 +314,9 @@ function vertexShader() {
     }
   `;
 }
+*/
 
-function vertexShaderNew() {
+function vertexShader() {
   return `
 attribute vec2 aVertexPosition;
 

--- a/editor.js
+++ b/editor.js
@@ -8,20 +8,14 @@ import { CodemirrorBinding } from "y-codemirror";
 import "codemirror/mode/clike/clike.js";
 import 'codemirror/addon/lint/lint';
 import {__fragmentShader, __vertexShader} from "./defaultShaders.js";
-import * as THREE from "three";
 
 const OT = require('@opentok/client');
 
-var container;
-var threeCam, scene, renderer;
 var uniforms;
 
 var gl;
 
 var editor;
-var geometry;
-var material;
-var mesh;
 
 var isDirty = false;
 
@@ -50,7 +44,6 @@ let vertexCount;
 // scalers.
 
 let uScalingFactor;
-let uGlobalColor;
 let uResolution;
 let uTime;
 let uRotationVector;
@@ -149,7 +142,6 @@ function initYdoc() {
   //linter takes care of calling checkFragmentShader so we dont need
   // this editor.on function
   onEdit();
-  //init();
   //animate();
 }
 
@@ -157,7 +149,7 @@ function initYdoc() {
 // this function will trigger a change to the editor
 function onEdit() {
   const fragmentCode = editor.getValue();
-  //updateShader(fragmentCode);
+  updateShader(fragmentCode);
 }
 
 function updateShader(fragmentCode) {
@@ -167,26 +159,7 @@ function updateShader(fragmentCode) {
 
   _fragmentShader = fragmentCode;
 
-  //isDirty = true;
-}
-
-function updateScene() {
-  scene = new THREE.Scene();
-  geometry = new THREE.PlaneBufferGeometry(2, 2);
-
-  try {
-    material = new THREE.ShaderMaterial({
-      uniforms: uniforms,
-      vertexShader: vertexShader(),
-      fragmentShader: fragmentShader()
-    });
-  } catch (e) {
-    console.log("MY ERROR", e);
-    return;
-  }
-
-  mesh = new THREE.Mesh(geometry, material);
-  scene.add(mesh);
+  isDirty = true;
 }
 
 window.onload = (event) => {
@@ -207,15 +180,12 @@ function animateScene() {
 
     uScalingFactor =
           gl.getUniformLocation(shaderProgram, "uScalingFactor");
-    uGlobalColor =
-          gl.getUniformLocation(shaderProgram, "uGlobalColor");
     uResolution =
           gl.getUniformLocation(shaderProgram, "u_resolution");
     uTime =
           gl.getUniformLocation(shaderProgram, "u_time");
 
     gl.uniform2fv(uScalingFactor, currentScale);
-    gl.uniform4fv(uGlobalColor, [0.1, 0.7, 0.2, 1.0]);
     gl.uniform2fv(uResolution, resolution);
     gl.uniform1f(uTime, previousTime);
 
@@ -303,34 +273,8 @@ function webgl_startup() {
 
 // DONE WITH COPIED SECTION
 
-function init() {
-  container = document.getElementById("container");
-
-  threeCam = new THREE.Camera();
-  threeCam.position.z = 1;
-
-  uniforms = {
-    u_time: { type: "f", value: 1.0 },
-    u_resolution: { type: "v2", value: new THREE.Vector2() },
-    time: { type: "f", value: 1.0 },
-    resolution: { type: "v2", value: new THREE.Vector2() },
-    u_mouse: { type: "v2", value: new THREE.Vector2() },
-    u_camRot: { type: "v3", value: new THREE.Vector3() },
-  };
-
-  updateScene();
-  container = document.getElementById("container");
-  renderer = new THREE.WebGLRenderer();
-  renderer.setPixelRatio(window.devicePixelRatio);
-
-  gl = renderer.getContext();
-
-  container.appendChild(renderer.domElement);
-
-  onWindowResize();
-  window.addEventListener("resize", onWindowResize, false);
-}
-
+// TODO call this with
+// window.addEventListener("resize", onWindowResize, false);
 function onWindowResize(event) {
   renderer.setSize(container.offsetWidth, container.offsetHeight);
   if (isInPresentationMode()) {
@@ -386,7 +330,6 @@ function fragmentShaderNew() {
     precision highp float;
   #endif
 
-  uniform vec4 uGlobalColor;
   uniform vec2 u_resolution;
   uniform float u_time;
 

--- a/present.html
+++ b/present.html
@@ -13,7 +13,11 @@
   </head>
   <body>
 
-    <div id="container" class="container-present"></div>
+    <div class="displaywrapper">
+      <canvas id="glcanvas" class="container">
+        Oh no! Your browser doesn't support canvas!
+      </canvas>
+    </div>
     <div id="editor"></div>
   </body>
 </html>

--- a/present.html
+++ b/present.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Shader.Place</title>
-    <script src="fragmentShader.js" defer></script>
+    <script src="defaultShaders.js" defer></script>
 
     <link rel=stylesheet href="https://codemirror.net/lib/codemirror.css"  async defer>
     <link rel="stylesheet" type="text/css" href="style.css" title="shaderplace">

--- a/style.css
+++ b/style.css
@@ -117,13 +117,8 @@ footer {
 
 #enterScreen { caret-color: red; text-align: center; z-index:-100}
 
-.container-edit {
+.container {
   height: 100vh;
-  width: 100%;
-}
-
-.container-present {
-  height: 100%;
   width: 100%;
 }
 


### PR DESCRIPTION
This change

* Removes all THREE references
* Enables using canvas + webgl directly
* Only passes the u_time and u_resolution uniforms through. We will have to add more code to support mouse data again.

Let me know if you want any changes. In particular, maybe we should get mouse stuff working on this branch before merging into main?

Anyway, this change went quite well and I'm generally happy with the result. I think this should fix any performance issues that existed before. 