### PR TITLE
Better support for line wrapping in editor mode

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -76,8 +76,8 @@ function initYdoc() {
     lineNumbers: true,
     mode: "x-shader/x-vertex",
     gutters: ["CodeMirror-lint-markers"],
-    lint: true//,
-    // lineWrapping: !isInPresentationMode()
+    lint: true,
+    lineWrapping: !isInPresentationMode()
   });
 
   const ytext = ydoc.getText("codemirror");


### PR DESCRIPTION
Sorry if this is annoying! I think this was disabled when you were testing the addition of editor mode. I think it works a little better with wrapping, since otherwise you have to scroll by highlighting? LMK if you don't like this change and I'm happy to drop it.